### PR TITLE
Fix issue-127

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -10,7 +10,8 @@
         <input type="checkbox" id="calendar"> <span class="checkboxtext"> Homepage Calendar </span> <br> <br>
         <input type="checkbox" id="badges"> <span class="checkboxtext"> Improved Badges </span> <br> <br>
         <input type="checkbox" id="college-services"> <span class="checkboxtext"> Improved College Services </span> <br> <br>
-        <input type="checkbox" id="ms-tools"> <span class="checkboxtext"> Improved My.Seneca Tools </span> <br> <br> <br> 
+        <input type="checkbox" id="ms-tools"> <span class="checkboxtext"> Improved My.Seneca Tools </span> <br> <br>
+        <input type="checkbox" id="fontSize"> <span class="checkboxtext"> Change Font Size Button </span> <br> <br> <br> 
         <h2>Remove Sections:</h2>
         <input type="checkbox" id="remove-course-survey"> <span class="checkboxtext"> Course Assessment Survey </span> <br> <br>
         <input type="checkbox" id="remove-dyk"> <span class="checkboxtext"> "Did You Know?" Section </span> <br> <br>

--- a/src/options.js
+++ b/src/options.js
@@ -73,7 +73,7 @@ chrome.storage.sync.get({
     themeDark: false,
     themeNew: false,
     forgotPass: true,
-    fontSize
+    fontSize: true
 }, function(items) {
     document.getElementById('adj-brightness').checked = items.brightness;
     document.getElementById('calendar').checked = items.calendar;


### PR DESCRIPTION
Fix [issue-127](https://github.com/yevseytsev/SenecaBlackboardExtension/issues/127)

Added the checkbox for font size option to match ``filesoption.js`` and ``background.js`` files, result like the image below:

<img width="399" alt="screen shot 2018-12-10 at 6 21 35 pm" src="https://user-images.githubusercontent.com/14205464/49768076-077b6500-fca9-11e8-9579-d46578b7f364.png">
